### PR TITLE
生成的订阅似乎缺了一个字段，或者是因为我的环境有问题？

### DIFF
--- a/src/views/Subconverter.vue
+++ b/src/views/Subconverter.vue
@@ -441,6 +441,7 @@ export default {
 
       this.customSubUrl =
         backend +
+        "sub?" + 
         "target=" +
         this.form.clientType +
         "&url=" +


### PR DESCRIPTION
根据[后端repo的wiki](https://github.com/tindy2013/subconverter#access-interface)似乎紧接着后端地址还应该加上``sub?``字段，在我这边（heroku）也是加上字段工作才正常，但我不确定其他环境，所以我把这个pr设为draft，如果确实存在尽请merge，如果是我的环境的问题的话辛苦您关掉这个pr。谢谢。