### PR TITLE
Fixed compatibility bugs

### DIFF
--- a/src/views/Subconverter.vue
+++ b/src/views/Subconverter.vue
@@ -408,21 +408,17 @@ export default {
         this.form.insert;
 
       if (this.advanced === "2") {
-        if (this.form.remoteConfig !== "") {
-          this.customSubUrl +=
-            "&config=" + encodeURIComponent(this.form.remoteConfig);
+        if (this.form.remoteConfig) {
+          this.customSubUrl += "&config=" + encodeURIComponent(this.form.remoteConfig);
         }
-        if (this.form.excludeRemarks !== "") {
-          this.customSubUrl +=
-            "&exclude=" + encodeURIComponent(this.form.excludeRemarks);
+        if (this.form.excludeRemarks) {
+          this.customSubUrl += "&exclude=" + encodeURIComponent(this.form.excludeRemarks);
         }
-        if (this.form.includeRemarks !== "") {
-          this.customSubUrl +=
-            "&include=" + encodeURIComponent(this.form.includeRemarks);
+        if (this.form.includeRemarks) {
+          this.customSubUrl += "&include=" + encodeURIComponent(this.form.includeRemarks);
         }
-        if (this.form.filename !== "") {
-          this.customSubUrl +=
-            "&filename=" + encodeURIComponent(this.form.filename);
+        if (this.form.filename) {
+          this.customSubUrl += "&filename=" + encodeURIComponent(this.form.filename);
         }
         if (this.form.appendType) {
           this.customSubUrl +=

--- a/src/views/Subconverter.vue
+++ b/src/views/Subconverter.vue
@@ -409,16 +409,20 @@ export default {
 
       if (this.advanced === "2") {
         if (this.form.remoteConfig) {
-          this.customSubUrl += "&config=" + encodeURIComponent(this.form.remoteConfig);
+          this.customSubUrl +=
+            "&config=" + encodeURIComponent(this.form.remoteConfig);
         }
         if (this.form.excludeRemarks) {
-          this.customSubUrl += "&exclude=" + encodeURIComponent(this.form.excludeRemarks);
+          this.customSubUrl +=
+            "&exclude=" + encodeURIComponent(this.form.excludeRemarks);
         }
         if (this.form.includeRemarks) {
-          this.customSubUrl += "&include=" + encodeURIComponent(this.form.includeRemarks);
+          this.customSubUrl +=
+            "&include=" + encodeURIComponent(this.form.includeRemarks);
         }
         if (this.form.filename) {
-          this.customSubUrl += "&filename=" + encodeURIComponent(this.form.filename);
+          this.customSubUrl +=
+            "&filename=" + encodeURIComponent(this.form.filename);
         }
         if (this.form.appendType) {
           this.customSubUrl +=


### PR DESCRIPTION
移除当没使用这些参数时，默认生成订阅后，强制附加的默认值 null，个别机场订阅会无法转换，因为附加了 exclued=null&include=null，在 MetaCubeX 魔改后端 、subconverter 官方上游后端最新 action commit 版本，转换时会触发不明的 has been ignored and will not be added 过滤行为，节点会全部被忽略，返回 No nodes were found!，无法转换， 预期行为应该是在后端定义默认值和空值，让后端处理这个逻辑，不建议前端未定义的情况下默认附加